### PR TITLE
Update DorisStreamLoadVisitor.java

### DIFF
--- a/doriswriter/src/main/java/com/dorisdb/connector/datax/plugin/writer/doriswriter/manager/DorisStreamLoadVisitor.java
+++ b/doriswriter/src/main/java/com/dorisdb/connector/datax/plugin/writer/doriswriter/manager/DorisStreamLoadVisitor.java
@@ -96,7 +96,7 @@ public class DorisStreamLoadVisitor {
     private byte[] joinRows(List<String> rows, int totalBytes) {
         if (DorisWriterOptions.StreamLoadFormat.CSV.equals(writerOptions.getStreamLoadFormat())) {
             Map<String, Object> props = writerOptions.getLoadProps();
-            byte[] lineDelimiter = DorisDelimiterParser.parse( (String) props.get("row_delimiter")), "\n").getBytes(StandardCharsets.UTF_8);
+            byte[] lineDelimiter = DorisDelimiterParser.parse( (String) props.get("row_delimiter"), "\n").getBytes(StandardCharsets.UTF_8);
             ByteBuffer bos = ByteBuffer.allocate(totalBytes + rows.size() * lineDelimiter.length);
             for (String row : rows) {
                 bos.put(row.getBytes(StandardCharsets.UTF_8));

--- a/doriswriter/src/main/java/com/dorisdb/connector/datax/plugin/writer/doriswriter/manager/DorisStreamLoadVisitor.java
+++ b/doriswriter/src/main/java/com/dorisdb/connector/datax/plugin/writer/doriswriter/manager/DorisStreamLoadVisitor.java
@@ -96,7 +96,7 @@ public class DorisStreamLoadVisitor {
     private byte[] joinRows(List<String> rows, int totalBytes) {
         if (DorisWriterOptions.StreamLoadFormat.CSV.equals(writerOptions.getStreamLoadFormat())) {
             Map<String, Object> props = writerOptions.getLoadProps();
-            byte[] lineDelimiter = DorisDelimiterParser.parse(String.valueOf(props.get("row_delimiter")), "\n").getBytes(StandardCharsets.UTF_8);
+            byte[] lineDelimiter = DorisDelimiterParser.parse( (String) props.get("row_delimiter")), "\n").getBytes(StandardCharsets.UTF_8);
             ByteBuffer bos = ByteBuffer.allocate(totalBytes + rows.size() * lineDelimiter.length);
             for (String row : rows) {
                 bos.put(row.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
when props.get("row_delimiter") return null , String.valueOf(props.get("row_delimiter")) will get String 'null' ,it will end up let  lineDelimiter "null".getBytes(StandardCharsets.UTF_8)